### PR TITLE
constructor updates and unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MultiAssayExperiment
 Title: Create Classes and Functions for Managing Multiple Assays on Sets of
     Samples
-Version: 0.101.42
+Version: 0.101.43
 Author: MultiAssay SIG
 Description: Develop an integrative environment where multiple assays are
     managed and preprocessed for genomic data analysis.

--- a/R/MultiAssayExperiment.R
+++ b/R/MultiAssayExperiment.R
@@ -23,7 +23,68 @@
     autoMap
 }
 
-#' Create a MultiAssayExperiment object
+.harmonize <- function(experiments, pData, sampleMap) {
+    harmony <- character()
+    ## experiment and sampleMap assays need to agree
+    assay <- intersect(names(experiments), levels(sampleMap[["assay"]]))
+    keep_sampleMap_assay <- sampleMap[["assay"]] %in% assay
+    if (!all(keep_sampleMap_assay)) {
+        sampleMap <- sampleMap[keep_sampleMap_assay, , drop=FALSE]
+        sampleMap[["assay"]] <- factor(sampleMap[["assay"]], levels=assay)
+        harmony <- c(
+            harmony,
+            paste("removing", sum(!keep_sampleMap_assay),
+                  "sampleMap rows not in names(experiments)"))
+    }
+
+    ## experiment colnames and sampleMap colname need to agree
+    grp <- sampleMap$assay
+    colnm = split(sampleMap$colname, grp)
+    keep = Map(intersect, colnm, colnames(experiments)[names(colnm)])
+    keep_sampleMap_colname = logical(nrow(sampleMap))
+    split(keep_sampleMap_colname, grp) <- Map("%in%", colnm, keep)
+    if (!all(keep_sampleMap_colname)) {
+        sampleMap <- sampleMap[keep_sampleMap_colname, , drop=FALSE]
+        harmony <- c(
+            harmony,
+            paste("removing", sum(!keep_sampleMap_colname),
+                  "sampleMap rows with 'colname' not in colnames of experiments"))
+    }
+
+    ## primary and sampleMap primary need to agree
+    primary <- intersect(rownames(pData), sampleMap[["primary"]])
+    keep_sampleMap_primary <- sampleMap[["primary"]] %in% primary
+    if (!all(keep_sampleMap_primary)) {
+        sampleMap <- sampleMap[keep_sampleMap_primary,, drop=FALSE]
+        harmony <- c(
+            harmony,
+            paste("removing", sum(!keep_sampleMap_primary),
+                  "sampleMap rows with 'primary' not in pData"))
+    }
+
+    ## update objects
+    assay <- intersect(names(experiments), levels(sampleMap[["assay"]]))
+    experiments_columns <- split(sampleMap[["colname"]], sampleMap[["assay"]])
+    primary <- intersect(rownames(pData), sampleMap[["primary"]])
+    keep_pData <- rownames(pData) %in% primary
+    if (!all(keep_pData)){
+        pData=pData[keep_pData,]
+        harmony <- c(
+            harmony,
+            paste("removing", sum(!keep_pData),
+                  "pData rownames not in sampleMap 'primary'"))
+    }
+
+    experiments <- ExperimentList(Map(function(x, idx) {
+        x[, colnames(x) %in% idx, drop=FALSE]
+    }, experiments[assay], experiments_columns[assay]))
+
+    if (length(harmony))
+        message("harmonizing input:\n  ", paste(harmony, collapse="\n  "))
+    list(experiments=experiments, sampleMap=sampleMap, pData=pData)
+}
+
+#' #' Create a MultiAssayExperiment object
 #'
 #' This is the constructor function for the \link{MultiAssayExperiment-class}.
 #' It combines multiple data elements from the different hierarchies of data
@@ -55,37 +116,51 @@ MultiAssayExperiment <-
             sampleMap = S4Vectors::DataFrame(),
             metadata = NULL,
             drops = list()) {
-        if (inherits(experiments, "list"))
+
+        if (missing(experiments))
+            experiments = ExperimentList()
+        else
             experiments <- ExperimentList(experiments)
-        else if (!inherits(experiments, "SimpleList"))
-            stop("'experiments' must be a list or ExperimentList")
-        if (!is(pData, "DataFrame"))
+
+
+        if (missing(pData)){
+            allsamps <- unique(unlist(unname(colnames(experiments))))
+            pData <- S4Vectors::DataFrame(row.names = allsamps)
+        } else if (!is(pData, "DataFrame"))
             pData <- S4Vectors::DataFrame(pData)
-        if (!is(sampleMap, "DataFrame"))
+
+
+        if (missing(sampleMap)){
+            sampleMap <- .generateMap(pData, experiments)
+        } else {
             sampleMap <- S4Vectors::DataFrame(sampleMap)
-        if (!all(c(ncol(sampleMap) == 0L,
-                    ncol(pData) == 0L,
-                    length(experiments) == 0L))) {
-            if ((ncol(sampleMap) == 0L) && (ncol(pData) == 0L)) {
-                allsamps <- unique(unlist(unname(colnames(experiments))))
-                pData <- S4Vectors::DataFrame(row.names = allsamps)
-                sampleMap <- .generateMap(pData, experiments)
-            } else if ((ncol(sampleMap) == 0L) && (ncol(pData) != 0L)) {
-                sampleMap <- .generateMap(pData, experiments)
-                validAssays <-
-                    S4Vectors::split(
-                        sampleMap[["colname"]], sampleMap[, "assay"])
-                experiments <- mapply(function(x, y) {
-                    x[, y, drop = FALSE]
-                }, experiments, validAssays, SIMPLIFY = FALSE)
-                experiments <- ExperimentList(experiments)
+            if (!all(c("assay", "primary", "colname") %in% colnames(sampleMap)))
+                stop("'sampleMap' does not have required columns")
+            if (!is.factor(sampleMap[["assay"]]))
+                sampleMap[["assay"]] <- factor(sampleMap[["assay"]])
+            if (!is.character(sampleMap[["primary"]])) {
+                warning("sampleMap[['primary']] coerced to character()")
+                sampleMap[["primary"]] <- as.character(sampleMap[["primary"]])
+            }
+            if (!is.character(sampleMap[["colname"]])) {
+                warning("sampleMap[['colname']] coerced to character()")
+                sampleMap[["colname"]] <- as.character(sampleMap[["colname"]])
             }
         }
 
+        bliss <- .harmonize(experiments, pData, sampleMap)
+
+        ## validAssays <- S4Vectors::split(
+        ##     sampleMap[["colname"]], sampleMap[, "assay"])
+        ## experiments <- ExperimentList(Map(function(x, y) {
+        ##     x[, y]
+        ## }, experiments, validAssays))
+
+
         newMultiAssay <- new("MultiAssayExperiment",
-                             ExperimentList = experiments,
-                             pData = pData,
-                             sampleMap = sampleMap,
+                             ExperimentList = bliss[["experiments"]],
+                             pData = bliss[["pData"]],
+                             sampleMap = bliss[["sampleMap"]],
                              metadata = metadata)
         return(newMultiAssay)
     }

--- a/tests/testthat/test-MultiAssayExperiment.R
+++ b/tests/testthat/test-MultiAssayExperiment.R
@@ -1,12 +1,111 @@
-test_that("MultiAssayExperiment constructors work", {
-    expect_true(validObject(MultiAssayExperiment()))
+test_that("MultiAssayExperiment constructor works", {
 
+    obs <- MultiAssayExperiment()
+    expect_true(validObject(obs))
+    expect_identical(names(experiments(obs)), character())
+    expect_identical(length(experiments(obs)), 0L)
+    expect_identical(dim(sampleMap(obs)), c(0L, 3L))
+    expect_identical(dim(pData(obs)), c(0L, 0L))
+    
     expect_error(MultiAssayExperiment(list(matrix(0, 0, 0))),
                  label="unnamed ExperimentList")
-
+    
     obs <- MultiAssayExperiment(list(m=matrix(0, 0, 0)))
     expect_true(validObject(obs))
-
-    obs <- MultiAssayExperiment(list(stack=GenomicFiles::VcfStack()))
+    expect_identical(names(experiments(obs)), "m")
+    expect_identical(length(experiments(obs)), 1L)
+    expect_identical(dim(sampleMap(obs)), c(0L, 3L))
+    expect_identical(dim(pData(obs)), c(0L, 0L))
+        
+    pData = S4Vectors::DataFrame(row.names=letters[1:4])
+    obs <- MultiAssayExperiment(pData=pData)
     expect_true(validObject(obs))
+    expect_identical(names(experiments(obs)), character())
+    expect_identical(length(experiments(obs)), 0L)
+    expect_identical(dim(sampleMap(obs)), c(0L, 3L))
+    expect_identical(dim(pData(obs)), c(0L, 0L))
+        
+    sampleMap = S4Vectors::DataFrame(assay=factor("m", levels="m"),
+        primary=letters, colname=letters)
+    obs <- MultiAssayExperiment(sampleMap=sampleMap)
+    expect_true(validObject(obs))
+    expect_identical(nrow(sampleMap(obs)), 0L)
+    expect_identical(length(experiments(obs)), 0L)
+    expect_identical(dim(pData(obs)), c(0L, 0L))
+
+    # test multiple experiment 
+    m <- matrix(0, 3, 3, dimnames=list(letters[1:3], letters[1:3]))
+    m2 <- matrix(0,0,0)
+    m3 <- matrix(0,1,1,dimnames=list("d","d"))
+    obs <- MultiAssayExperiment(list(m=m, m2=m2, m3=m3))
+    expect_true(validObject(obs))
+    expect_identical(length(experiments(obs)), 3L)
+    expect_identical(levels(sampleMap(obs)[["assay"]]), c("m", "m2", "m3"))
+    expect_identical(dim(sampleMap(obs)), c(4L, 3L))
+    expect_identical(rownames(pData(obs)), sampleMap(obs)[["primary"]])
+    
+})
+
+
+test_that("MultiAssayExperiment .harmonize construction helper works", {
+
+    # remove unused assays in experiments not in sampleMap 
+    m <- matrix(0, 2, 2, dimnames=list(letters[1:2], letters[1:2]))
+    experiments <- ExperimentList(list(m=m))
+    sampleMap <- S4Vectors::DataFrame(assay=factor("m", levels="m"),
+        primary="a", colname="a")
+    obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap)
+    expect_identical(colnames(obs)[[1]], "a")
+    expect_identical(sampleMap(obs), sampleMap)
+    expect_identical(row.names(pData(obs)) , "a")
+
+    # removed unused assays in sampleMap
+    sampleMap <- S4Vectors::DataFrame(assay=factor("m", levels="m"),
+        primary=letters, colname=letters)
+    obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap)
+    expect_identical(colnames(experiments)[[1]], sampleMap(obs)[["colname"]])
+    expect_identical(experiments(obs), experiments)
+    expect_identical(colnames(experiments)[[1]], rownames(pData(obs)))
+    expect_identical(rownames(pData(obs)), sampleMap(obs)[["primary"]])
+
+    # pData subset by sampleData primary 
+    pData <- S4Vectors::DataFrame(matrix(0, 4, 4, dimnames=list(letters[1:4], letters[1:4])))
+    obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap, pData=pData)
+    expect_identical(rownames(pData(obs)), sampleMap(obs)[["primary"]])
+
+    # combo subset
+    sampleMap <- S4Vectors::DataFrame(
+        assay=factor(c("m","stack"), levels=c("m","stack")),
+        primary=c("a","n"),
+        colname=c("a","n"))
+    m <- matrix(0, 3, 3, dimnames=list(letters[1:3], letters[1:3]))
+    pData <- S4Vectors::DataFrame(matrix(0, 4, 4, dimnames=list(letters[1:4], letters[1:4])))
+    experiments <- ExperimentList(list(m=m))
+    obs <- MultiAssayExperiment(experiments=experiments, sampleMap=sampleMap, pData=pData)
+    expect_identical(colnames(obs)[[1]], "a")
+    expect_identical(dim(sampleMap(obs)), c(1L, 3L))
+    expect_identical(rownames(pData(obs)), sampleMap(obs)[["primary"]])
+
+    # test multiple experiment, combo subsetting
+    m <- matrix(0, 3, 3, dimnames=list(letters[1:3], letters[1:3]))
+    m2 <- matrix(0,0,0)
+    m3 <- matrix(0,2,2,dimnames=list(letters[4:5],letters[4:5]))
+    experiments <- ExperimentList(list(m=m, m2=m2, m3=m3))
+    sampleMap <- S4Vectors::DataFrame(
+        assay=factor(c("m","stack","m3"), levels=c("m","stack","m3")),
+        primary=c("a","n","d"),
+        colname=c("a","n","d"))
+    pData <- S4Vectors::DataFrame(matrix(0, 7, 7, dimnames=list(letters[1:7], letters[1:7])))
+    obs <- MultiAssayExperiment(experiments=experiments, sampleMap=sampleMap, pData=pData)
+    expect_true(validObject(obs))
+    expect_identical(length(experiments(obs)), 2L)
+    expect_identical(dim(experiments(obs)[[1]]), c(3L, 1L))
+    expect_identical(dim(experiments(obs)[[2]]), c(2L, 1L))
+    expect_identical(names(experiments(obs)), c("m", "m3"))
+    expect_identical(dim(sampleMap(obs)), c(2L, 3L))
+    expect_identical(levels(sampleMap(obs)[["assay"]]), c("m", "m3"))
+    expect_identical(rownames(pData(obs)), sampleMap(obs)[["primary"]])
+    expect_identical(unlist(colnames(experiments(obs)), use.names=FALSE),
+                     row.names(pData(obs)))
+    
 })

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -5,7 +5,15 @@ setClass("MAEshell", slots = c(a = "RangedSummarizedExperiment"))
 setMethod("assay", "MAEshell", function(x) {assay(x@a)})
 setMethod("rownames", "MAEshell", function(x) {rownames(x@a)})
 setMethod("colnames", "MAEshell", function(x) {colnames(x@a)})
-setMethod("[", c("MAEshell", "ANY", "ANY"), function(x, i, j) {x@a[i, j]})
+setMethod("[", c("MAEshell", "ANY", "ANY"), function(x, i, j, ..., drop=TRUE) {
+    if (!missing(i) && !missing(j))
+        x@a[i, j, drop=drop]
+    else if (missing(i))
+        x@a[,j, drop=drop]
+    else if (missing(j))
+        x@a[i,,drop=drop]
+    else x
+})
 setMethod("dim", "MAEshell", function(x) {c(length(x@a),
                                             length(assay(x@a)[1,]))})
 


### PR DESCRIPTION
The aims of the proposed changes are to fix a few minor bugs and to coerce a valid object upon construction.   We have also extended unit tests of the constructor and proposed helper function. 

- SampleMap constructed with default columns. Originally an empty data frame with unnamed columns was created; the required columns "assay", "primary", and "colname" are now initialized. 

In the current code: 
```
> obs <- MultiAssayExperiment(list(m=matrix(0, 0, 0)))
> expect_identical(dim(sampleMap(obs)), c(0L, 3L))
Error: dim(sampleMap(obs)) not identical to c(0L, 3L).
1/2 mismatches
[2] 0 - 3 == -3
>   
> sampleMap(obs)
DataFrame with 0 rows and 0 columns
> colnames(sampleMap(obs))
character(0)
```
Now: 
```
> expect_identical(dim(sampleMap(obs)), c(0L, 3L))
> sampleMap(obs)
DataFrame with 0 rows and 3 columns
> colnames(sampleMap(obs))
[1] "assay"   "primary" "colname"

```
- More significantly we added an internal function to coerce the user input to be valid objects upon construction; this also entails dropping extra information in experiments, pData, and sampleMap that would not be consistent among all three elements. The thought process being that experiments that can not be mapped should be dropped, sampleMap assays that are listed but do not have an associated experiment should be dropped, and pData samples that are not in experiments/sampleMap should be dropped so that we aren't carrying information that is not being utilized.  See the following examples and different scenarios. 

\1. construction with pData only. 

current version keeps everything: 
```
>  pData = S4Vectors::DataFrame(row.names=letters[1:4])
>  obs <- MultiAssayExperiment(pData=pData)
>  expect_identical(dim(pData(obs)), c(0L, 0L))
Error: dim(pData(obs)) not identical to c(0L, 0L).
1/2 mismatches
[1] 4 - 0 == 4
>   pData(obs)
DataFrame with 4 rows and 0 columns

```
new version would create empty pData because the pData row.names do not match any 'primary' in sampleMap. Why carry extra phenotype data that are not found in the sampleMap/experiments
```
> obs <- MultiAssayExperiment(pData=pData)
harmonizing input:
  removing 4 pData rownames not in sampleMap 'primary'
>     pData(obs)
DataFrame with 0 rows and 0 columns
```

 \2. construction with sampleMap only 
Again the current version keeps everything: 
```
>     sampleMap = S4Vectors::DataFrame(assay=factor("m", levels="m"),
         primary=letters, colname=letters)
>     obs <- MultiAssayExperiment(sampleMap=sampleMap)
>     expect_identical(nrow(sampleMap(obs)), 0L)
Error: nrow(sampleMap(obs)) not identical to 0.
1/1 mismatches
[1] 26 - 0 == 26
> sampleMap(obs)
DataFrame with 26 rows and 3 columns
       assay     primary     colname
    <factor> <character> <character>
1          m           a           a
2          m           b           b
3          m           c           c
4          m           d           d
5          m           e           e
...      ...         ...         ...
22         m           v           v
23         m           w           w
24         m           x           x
25         m           y           y
26         m           z           z
```
New version would create an empty sampleMap because the sampleMap 'assay' does not match any experiments. The thought: does it make sense to carry mapping information if it doesn't map to anything?
```
> obs <- MultiAssayExperiment(sampleMap=sampleMap)
harmonizing input:
  removing 26 sampleMap rows not in names(experiments)
> sampleMap(obs)
DataFrame with 0 rows and 3 columns
```
 
The idea of coercing valid objects upon construction seems liked a helpful thing to do.  Perhaps better illustrations of the above subsetting can be seen with the following examples (new unit test cases): 

\1. remove unused/unmapped experiments 

current version: 
```
>  m <- matrix(0, 2, 2, dimnames=list(letters[1:2], letters[1:2]))
> m
  a b
a 0 0
b 0 0
>     experiments <- ExperimentList(list(m=m))
>     sampleMap <- S4Vectors::DataFrame(assay=factor("m", levels="m"),
+         primary="a", colname="a")
> sampleMap
DataFrame with 1 row and 3 columns
     assay     primary     colname
  <factor> <character> <character>
1        m           a           a
>     obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap)
Error in validObject(.Object) : 
  invalid class "MultiAssayExperiment" object: All samples in the sampleMap must be in the pData
```

new version will remove the unused experiments and make a valid object: 
```
>   m <- matrix(0, 2, 2, dimnames=list(letters[1:2], letters[1:2]))
>     experiments <- ExperimentList(list(m=m))
>     sampleMap <- S4Vectors::DataFrame(assay=factor("m", levels="m"),
+         primary="a", colname="a")
>     obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap)
harmonizing input:
  removing 1 pData rownames not in sampleMap 'primary'
>   experiments(obs)[[1]]
  a
a 0
b 0
>  sampleMap(obs)
DataFrame with 1 row and 3 columns
     assay     primary     colname
  <factor> <character> <character>
1        m           a           a
> pData(obs)
DataFrame with 1 row and 0 columns
```

\2.  remove unused sampleMap information

current version 
```
>  sampleMap <- S4Vectors::DataFrame(assay=factor("m", levels="m"),
+         primary=letters, colname=letters)
>     obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap)
Error in validObject(.Object) : 
  invalid class "MultiAssayExperiment" object: All samples in the sampleMap must be in the pData
>   sampleMap
DataFrame with 26 rows and 3 columns
       assay     primary     colname
    <factor> <character> <character>
1          m           a           a
2          m           b           b
3          m           c           c
4          m           d           d
5          m           e           e
...      ...         ...         ...
22         m           v           v
23         m           w           w
24         m           x           x
25         m           y           y
26         m           z           z
```

new version would pare down the sampleMap to keep only the mappings necessary for the experiments listed. 

```
>     obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap)
harmonizing input:
  removing 24 sampleMap rows with 'colname' not in colnames of experiments
> experiments(obs)[[1]]
  a b
a 0 0
b 0 0
> sampleMap(obs)
DataFrame with 2 rows and 3 columns
     assay     primary     colname
  <factor> <character> <character>
1        m           a           a
2        m           b           b
> pData(obs)
DataFrame with 2 rows and 0 columns
> row.names(pData(obs))
[1] "a" "b"
```
\3. remove the pData rows that do not match a 'primary' entry in the sampleMap
```
>  pData <- S4Vectors::DataFrame(matrix(0, 4, 4, dimnames=list(letters[1:4], letters[1:4])))
>     obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap, pData=pData)
Error in validObject(.Object) : 
  invalid class "MultiAssayExperiment" object: All samples in the sampleMap must be in the pData
> pData
DataFrame with 4 rows and 4 columns
          a         b         c         d
  <numeric> <numeric> <numeric> <numeric>
a         0         0         0         0
b         0         0         0         0
c         0         0         0         0
d         0         0         0         0
```

new version will pare down the pData to those in the sampleMap 
```
>   pData <- S4Vectors::DataFrame(matrix(0, 4, 4, dimnames=list(letters[1:4], letters[1:4])))
>     obs <- MultiAssayExperiment(experiments, sampleMap=sampleMap, pData=pData)
harmonizing input:
  removing 24 sampleMap rows with 'colname' not in colnames of experiments
  removing 2 pData rownames not in sampleMap 'primary'
> 
> experiments(obs)
ExperimentList class object of length 1: 
 [1] m: matrix with 2 rows and 2 columns 
> experiments(obs)[[1]]
  a b
a 0 0
b 0 0
> sampleMap(obs)
DataFrame with 2 rows and 3 columns
     assay     primary     colname
  <factor> <character> <character>
1        m           a           a
2        m           b           b
> pData(obs)
DataFrame with 2 rows and 4 columns
          a         b         c         d
  <numeric> <numeric> <numeric> <numeric>
a         0         0         0         0
b         0         0         0         0
```

\4. Here is a larger object to try and fully demonstrate the subsetting

Current version: 
```
>     m <- matrix(0, 3, 3, dimnames=list(letters[1:3], letters[1:3]))
>     m2 <- matrix(0,0,0)
>     m3 <- matrix(0,2,2,dimnames=list(letters[4:5],letters[4:5]))
>     experiments <- ExperimentList(list(m=m, m2=m2, m3=m3))
>     sampleMap <- S4Vectors::DataFrame(
+         assay=factor(c("m","stack","m3"), levels=c("m","stack","m3")),
+         primary=c("a","n","d"),
+         colname=c("a","n","d"))
>     pData <- S4Vectors::DataFrame(matrix(0, 7, 7, dimnames=list(letters[1:7], letters[1:7])))
>     obs <- MultiAssayExperiment(experiments=experiments, sampleMap=sampleMap, pData=pData)
Error in validObject(.Object) : 
  invalid class "MultiAssayExperiment" object: All samples in the sampleMap must be in the pData
>  experiments
ExperimentList class object of length 3: 
 [1] m: matrix with 3 rows and 3 columns 
 [2] m2: matrix with 0 rows and 0 columns 
 [3] m3: matrix with 2 rows and 2 columns 
> sampleMap
DataFrame with 3 rows and 3 columns
     assay     primary     colname
  <factor> <character> <character>
1        m           a           a
2    stack           n           n
3       m3           d           d
> pData
DataFrame with 7 rows and 7 columns
          a         b         c         d         e         f         g
  <numeric> <numeric> <numeric> <numeric> <numeric> <numeric> <numeric>
a         0         0         0         0         0         0         0
b         0         0         0         0         0         0         0
c         0         0         0         0         0         0         0
d         0         0         0         0         0         0         0
e         0         0         0         0         0         0         0
f         0         0         0         0         0         0         0
g         0         0         0         0         0         0         0
```

And with the new version a valid object is created and elements subset: 
```
>     m <- matrix(0, 3, 3, dimnames=list(letters[1:3], letters[1:3]))
>     m2 <- matrix(0,0,0)
>     m3 <- matrix(0,2,2,dimnames=list(letters[4:5],letters[4:5]))
>     experiments <- ExperimentList(list(m=m, m2=m2, m3=m3))
>     sampleMap <- S4Vectors::DataFrame(
+         assay=factor(c("m","stack","m3"), levels=c("m","stack","m3")),
+         primary=c("a","n","d"),
+         colname=c("a","n","d"))
>     pData <- S4Vectors::DataFrame(matrix(0, 7, 7, dimnames=list(letters[1:7], letters[1:7])))
>     obs <- MultiAssayExperiment(experiments=experiments, sampleMap=sampleMap, pData=pData)
harmonizing input:
  removing 1 sampleMap rows not in names(experiments)
  removing 5 pData rownames not in sampleMap 'primary'
> 
> experiments(obs)
ExperimentList class object of length 2: 
 [1] m: matrix with 3 rows and 1 columns 
 [2] m3: matrix with 2 rows and 1 columns 
> sampleMap(obs)
DataFrame with 2 rows and 3 columns
     assay     primary     colname
  <factor> <character> <character>
1        m           a           a
2       m3           d           d
> pData(obs)
DataFrame with 2 rows and 7 columns
          a         b         c         d         e         f         g
  <numeric> <numeric> <numeric> <numeric> <numeric> <numeric> <numeric>
a         0         0         0         0         0         0         0
d         0         0         0         0         0         0         0
```

Note how all examples are made to be valid objects and drop unused information. 

